### PR TITLE
Updating for Crystal 1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,12 @@ workflows:
   version: 2
   test:
     jobs:
-    - test_crystal_0_26_1
-    # - test_crystal_nightly
+    - test_crystal_0_36_1
+    - test_crystal_nightly
 jobs:
-  test_crystal_0_26_1:
+  test_crystal_0_36_1:
     docker:
-    - image: 'crystallang/crystal:0.26.1'
+    - image: 'crystallang/crystal:0.36.1'
     working_directory: ~/repo
     steps:
     - checkout

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.8.2
 authors:
   - mosop
 
-crystal: 0.35.0
+crystal: ">= 0.35.0, < 2.0.0"
 
 dependencies:
   future:

--- a/shard.yml
+++ b/shard.yml
@@ -13,8 +13,8 @@ dependencies:
 
 development_dependencies:
   have_files:
-    github: mosop/have_files
-    version: ~> 0.4.0
+    github: jwoertink/have_files
+    branch: crystal1.0
   stdio:
     github: mosop/stdio
     version: ~> 0.1.2

--- a/shard.yml
+++ b/shard.yml
@@ -12,9 +12,6 @@ dependencies:
     version: ~> 0.1.0
 
 development_dependencies:
-  have_files:
-    github: jwoertink/have_files
-    branch: crystal1.0
   stdio:
     github: mosop/stdio
     version: ~> 0.1.2

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.8.2
 authors:
   - mosop
 
-crystal: ">= 0.35.0, < 2.0.0"
+crystal: ">= 0.36.1, < 2.0.0"
 
 dependencies:
   future:

--- a/spec/features/filtering_file_entries_spec.cr
+++ b/spec/features/filtering_file_entries_spec.cr
@@ -15,7 +15,7 @@ module TeeplateFilteringFileEntriesFeature
     end
 
     def rendered_file_entries
-      super.select{|i| !i.path.ends_with?("shard.yml")}
+      super.select { |i| !i.path.ends_with?("shard.yml") }
     end
   end
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,6 +1,6 @@
 require "spec"
 require "future"
-require "have_files/spec/dsl"
+require "./support/**"
 require "../src/teeplate"
 
 module Teeplate::SpecHelper

--- a/spec/support/have_files/README.md
+++ b/spec/support/have_files/README.md
@@ -1,0 +1,40 @@
+# have_files
+
+A Crystal Spec/spec2 matcher for testing if two file trees are identical.
+
+View the [original shard](https://github.com/mosop/have_files) for more information.
+
+## Contributors
+
+- [mosop](https://github.com/mosop) - creator, maintainer
+
+## License
+
+The MIT License (MIT)
+
+Copyright (c) 2016 mosop
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+## Notes
+
+This shard has been inlined for spec use. The [original shard](https://github.com/mosop/have_files) has additional
+support for other testing libraries that are not needed here. All of the code was originally written by [mosop](https://github.com/mosop)
+and minimally updated to remove dependencies from this version of `teeplate`.

--- a/spec/support/have_files/dsl.cr
+++ b/spec/support/have_files/dsl.cr
@@ -1,0 +1,9 @@
+require "./expectation"
+
+module HaveFiles::Spec
+  module Dsl
+    def have_files(expected_dir, base_dir = "/tmp", cleanup = true)
+      Expectation.new(expected_dir, base_dir: base_dir, cleanup: cleanup)
+    end
+  end
+end

--- a/spec/support/have_files/have_files.cr
+++ b/spec/support/have_files/have_files.cr
@@ -1,0 +1,36 @@
+module HaveFiles
+  VERSION = "0.3.4"
+
+  module C
+    lib Lib
+      fun mkdtemp(template : LibC::Char*) : LibC::Char*
+    end
+  end
+
+  def self.tmpdir(base : String = "/tmp", cleanup : Bool = true, &block)
+    ptmpdir = "#{base}/XXXXXX".bytes + [0_u8]
+    raise "mkdtemp() error." if C::Lib.mkdtemp(ptmpdir) == 0
+    tmpdir = String.new(ptmpdir.to_unsafe)
+    begin
+      yield tmpdir
+    ensure
+      rm_r tmpdir if cleanup
+    end
+  end
+
+  def self.rm_r(path)
+    if Dir.exists?(path) && !File.symlink?(path)
+      Dir.open(path) do |dir|
+        dir.each do |entry|
+          if entry != "." && entry != ".."
+            src = File.join(path, entry)
+            rm_r(src)
+          end
+        end
+      end
+      FileUtils.rmdir(path)
+    else
+      File.delete(path) if File.exists?(path)
+    end
+  end
+end

--- a/src/lib/file_data.cr
+++ b/src/lib/file_data.cr
@@ -9,7 +9,7 @@ module Teeplate
     getter? forces : Bool
 
     def initialize(@absolute_path, @path, size : UInt64? = nil, perm : File::Permissions? = nil, force = false)
-      @size = size || File.size(@absolute_path)
+      @size = size || File.size(@absolute_path).to_u64
       @perm = perm || File.info(@absolute_path).permissions
       @forces = force
     end

--- a/src/lib/file_tree.cr
+++ b/src/lib/file_tree.cr
@@ -9,6 +9,7 @@ module Teeplate
     end
 
     @file_entries : Array(AsDataEntry)?
+
     # Returns collected file entries.
     def file_entries : Array(AsDataEntry)
       @file_entries ||= begin
@@ -42,7 +43,7 @@ module Teeplate
     # Collects file entries from the *dir* directory.
     def collect_from(dir, unique = false, relative_dir = nil)
       FileEntryCollector.new(File.expand_path(dir, Dir.current), relative_dir: relative_dir).entries.each do |entry|
-        file_entries << entry unless file_entries.find{|i| i.path == entry.path}
+        file_entries << entry unless file_entries.find { |i| i.path == entry.path }
       end
     end
   end

--- a/src/lib/renderer.cr
+++ b/src/lib/renderer.cr
@@ -85,7 +85,7 @@ module Teeplate
     # Starts rendering.
     def render
       begin
-        sorted_entries = @entries.sort{|a, b| a.local_path <=> b.local_path}
+        sorted_entries = @entries.sort { |a, b| a.local_path <=> b.local_path }
         sorted_entries.each do |entry|
           if @per_entry
             entry.render


### PR DESCRIPTION
This PR is to open up the crystal version restrictions so it can be used going past 1.0. The specs fail to run locally due to `HaveFiles`, but I [opened up an issue](https://github.com/mosop/have_files/issues/7). 