### PR TITLE
Release 0.8.4

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: teeplate
-version: 0.8.3
+version: 0.8.4
 
 authors:
   - mosop

--- a/src/version.cr
+++ b/src/version.cr
@@ -1,3 +1,3 @@
 module Teeplate
-  VERSION = "0.8.3"
+  VERSION = "0.8.4"
 end


### PR DESCRIPTION
This release just locks the `future` dependency shard to a version instead of master branch. 