### PR TITLE
Remove unnecessary future dependency

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -6,11 +6,6 @@ authors:
 
 crystal: ">= 0.36.1, < 2.0.0"
 
-dependencies:
-  future:
-    github: crystal-community/future.cr
-    version: ~> 1.0.0
-
 development_dependencies:
   stdio:
     github: mosop/stdio

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,5 +1,4 @@
 require "spec"
-require "future"
 require "./support/**"
 require "../src/teeplate"
 
@@ -25,7 +24,7 @@ module Teeplate::SpecHelper
   end
 
   def interact(io, answers, prompt = "", buffer = nil)
-    future do
+    spawn do
       loop do
         if ch = io.out!.read_char
           if buf = buffer
@@ -40,7 +39,7 @@ module Teeplate::SpecHelper
             break
           end
         else
-          future do
+          spawn do
             interact io, answers, prompt, buffer: buffer
             nil
           end

--- a/src/lib/rendering_entry.cr
+++ b/src/lib/rendering_entry.cr
@@ -1,5 +1,3 @@
-require "future"
-
 module Teeplate
   class RenderingEntry
     # :nodoc:
@@ -142,7 +140,7 @@ module Teeplate
         return false if File.size(out_path) != size
       end
       r, w = IO.pipe
-      future do
+      spawn do
         @data.write_to w
         w.close
       end
@@ -203,7 +201,7 @@ module Teeplate
     # :nodoc:
     def diff
       r, w = IO.pipe
-      future do
+      spawn do
         begin
           @data.write_to w
         ensure
@@ -211,7 +209,7 @@ module Teeplate
         end
       end
       r2, w2 = IO.pipe
-      future do
+      spawn do
         begin
           r2.each_byte do |n|
             STDOUT.write_byte n


### PR DESCRIPTION
The way the future library worked was:
- No delay was set so it called `spawn_compute` https://github.com/crystal-community/future.cr/blob/9fe168418c6884cb3552c13b004763eb4815ceb9/src/future.cr#L28
- `spawn_compute` uses `spawn` and calls `run_compute` https://github.com/crystal-community/future.cr/blob/9fe168418c6884cb3552c13b004763eb4815ceb9/src/future.cr#L77-L83
- `run_compute` just calls the passed in block https://github.com/crystal-community/future.cr/blob/9fe168418c6884cb3552c13b004763eb4815ceb9/src/future.cr#L85-L102

All of that can be simplified to to just replacing `future` with `spawn`. Gotta love unnecessary complexity, right?